### PR TITLE
build ffmpeg.wasm with lgplv2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -152,6 +152,8 @@ FROM ffmpeg-base AS ffmpeg-builder
 COPY build/ffmpeg.sh /src/build.sh
 RUN bash -x /src/build.sh \
       --disable-gpl \
+      --disable-version3 \
+      --disable-nonfree \
       --disable-postproc \
       --enable-libvpx \
       --enable-libmp3lame \


### PR DESCRIPTION
### やったこと
* ffmpegをLGPLv2.1のライセンスでビルドできるようにffmpegビルド時のオプションを追加