### PR TITLE
fix: able to build ffmpeg.wasm on mac

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-# syntax=docker/dockerfile-upstream:master-labs
-
 # Base emsdk image with environment variables.
+# NOTE:
+# - 元の `docker/dockerfile-upstream:master-labs` は Docker Hub からフロントエンドイメージを取得できない環境だと
+#   `failed to resolve source metadata ... i/o timeout` でビルドが開始できません。
+# - この Dockerfile は labs 専用構文を使っていないため、syntax 指定を外して BuildKit のデフォルトフロントエンドで動かします。
 FROM emscripten/emsdk:3.1.40 AS emsdk-base
 ARG EXTRA_CFLAGS
 ARG EXTRA_LDFLAGS
 ARG FFMPEG_ST
 ARG FFMPEG_MT
+ARG MAKE_JOBS=1
+ENV MAKE_JOBS=$MAKE_JOBS
 ENV INSTALL_DIR=/opt
 # We cannot upgrade to n6.0 as ffmpeg bin only supports multithread at the moment.
 ENV FFMPEG_VERSION=n5.1.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
 # Base emsdk image with environment variables.
-# NOTE:
-# - 元の `docker/dockerfile-upstream:master-labs` は Docker Hub からフロントエンドイメージを取得できない環境だと
-#   `failed to resolve source metadata ... i/o timeout` でビルドが開始できません。
-# - この Dockerfile は labs 専用構文を使っていないため、syntax 指定を外して BuildKit のデフォルトフロントエンドで動かします。
 FROM emscripten/emsdk:3.1.40 AS emsdk-base
 ARG EXTRA_CFLAGS
 ARG EXTRA_LDFLAGS

--- a/build/aom.sh
+++ b/build/aom.sh
@@ -24,4 +24,4 @@ emmake cmake .. \
   -DAOM_EXTRA_C_FLAGS="$CFLAGS" \
   -DAOM_EXTRA_CXX_FLAGS="$CFLAGS" \
   ${CM_FLAGS[@]}
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/ffmpeg.sh
+++ b/build/ffmpeg.sh
@@ -30,4 +30,4 @@ CONF_FLAGS=(
 )
 
 emconfigure ./configure "${CONF_FLAGS[@]}" $@
-emmake make -j
+emmake make -j"${MAKE_JOBS:-1}"

--- a/build/freetype2.sh
+++ b/build/freetype2.sh
@@ -12,4 +12,4 @@ emconfigure ./autogen.sh
 emconfigure ./configure "${CONF_FLAGS[@]}"
 # build apinames manually to prevent it built by emcc
 gcc -o objs/apinames src/tools/apinames.c
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/fribidi.sh
+++ b/build/fribidi.sh
@@ -12,5 +12,5 @@ CONF_FLAGS=(
 )
 emconfigure ./autogen.sh "${CONF_FLAGS[@]}"
 # A hacky to fix "Too many symbolic links" error
-emmake make install -j || true
+emmake make install -j"${MAKE_JOBS:-1}" || true
 mkdir -p $INSTALL_DIR/lib/pkgconfig && cp fribidi.pc $INSTALL_DIR/lib/pkgconfig/

--- a/build/harfbuzz.sh
+++ b/build/harfbuzz.sh
@@ -19,4 +19,4 @@ CONF_FLAGS=(
 )
 
 emconfigure ./autogen.sh "${CONF_FLAGS[@]}"
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/lame.sh
+++ b/build/lame.sh
@@ -12,4 +12,4 @@ CONF_FLAGS=(
   --disable-gtktest
 )
 CFLAGS=$CFLAGS emconfigure ./configure "${CONF_FLAGS[@]}"
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/libass.sh
+++ b/build/libass.sh
@@ -13,4 +13,4 @@ CONF_FLAGS=(
 )
 
 ./autogen.sh && emconfigure ./configure "${CONF_FLAGS[@]}"
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/libvpx.sh
+++ b/build/libvpx.sh
@@ -17,6 +17,6 @@ CONF_FLAGS=(
 )
 
 emconfigure ./configure "${CONF_FLAGS[@]}"
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"
 # Fix ffmpeg configure error: "libvpx enabled but no supported decoders found"
 emranlib $INSTALL_DIR/lib/libvpx.a

--- a/build/ogg.sh
+++ b/build/ogg.sh
@@ -12,4 +12,4 @@ CONF_FLAGS=(
 
 emconfigure ./autogen.sh
 emconfigure ./configure "${CONF_FLAGS[@]}"
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/opus.sh
+++ b/build/opus.sh
@@ -16,4 +16,4 @@ CONF_FLAGS=(
 
 emconfigure ./autogen.sh
 CFLAGS=$CFLAGS emconfigure ./configure "${CONF_FLAGS[@]}"
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/theora.sh
+++ b/build/theora.sh
@@ -17,4 +17,4 @@ CONF_FLAGS=(
 )
 
 emconfigure ./autogen.sh "${CONF_FLAGS[@]}"
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/vorbis.sh
+++ b/build/vorbis.sh
@@ -17,4 +17,4 @@ CONF_FLAGS=(
 )
 
 emconfigure ./autogen.sh "${CONF_FLAGS[@]}"
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/wavpack.sh
+++ b/build/wavpack.sh
@@ -16,4 +16,4 @@ CONF_FLAGS=(
   --disable-maintainer-mode
 )
 CFLAGS=$CFLAGS emconfigure ./autogen.sh "${CONF_FLAGS[@]}"
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/x264.sh
+++ b/build/x264.sh
@@ -13,4 +13,4 @@ CONF_FLAGS=(
 )
 
 emconfigure ./configure "${CONF_FLAGS[@]}"
-emmake make install-lib-static -j
+emmake make install-lib-static -j"${MAKE_JOBS:-1}"

--- a/build/x265.sh
+++ b/build/x265.sh
@@ -39,17 +39,17 @@ mkdir -p main 10bit 12bit
 
 cd 12bit
 emmake cmake ../.. -DCMAKE_CXX_FLAGS="$CXXFLAGS" ${FLAGS_12BIT[@]}
-emmake make -j
+emmake make -j"${MAKE_JOBS:-1}"
 
 cd ../10bit 
 emmake cmake ../.. -DCMAKE_CXX_FLAGS="$CXXFLAGS" ${FLAGS_10BIT[@]}
-emmake make -j
+emmake make -j"${MAKE_JOBS:-1}"
 
 cd ../main
 ln -sf ../10bit/libx265.a libx265_main10.a
 ln -sf ../12bit/libx265.a libx265_main12.a
 emmake cmake ../.. -DCMAKE_CXX_FLAGS="$CXXFLAGS" ${FLAGS_MAIN[@]}
-emmake make -j
+emmake make -j"${MAKE_JOBS:-1}"
 mv libx265.a libx265_main.a
 
 # Merge static libraries
@@ -61,4 +61,4 @@ ADDLIB libx265_main12.a
 SAVE
 END
 EOF
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"

--- a/build/zimg.sh
+++ b/build/zimg.sh
@@ -14,4 +14,4 @@ CONF_FLAGS=(
 emconfigure ./autogen.sh
 
 emconfigure ./configure "${CONF_FLAGS[@]}"
-emmake make install -j
+emmake make install -j"${MAKE_JOBS:-1}"


### PR DESCRIPTION
### 概要
Mac環境でffmpeg.wasmのビルドができなかったので修正

### やったこと
- `DOCKER_PLATFORM`という環境変数経由でインストールするdocker imageを指定できるように
- 並列でスクリプトを実行すると重すぎて、Docker環境ごと落ちることがあるため、スクリプトを1つずつ実行するように修正